### PR TITLE
Added functionality to configure initial time via query string

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <footer>
         <p>
             <a href="https://about.softuni.bg">Software University</a>
-            @
+            &copy;
             <span class="year"></span>
         </p>
     </footer>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
             <span class="year"></span>
         </p>
     </footer>
-    <script type="module" src="../scripts/index.js"></script>
+    <script type="module" src="/scripts/index.js"></script>
 </body>
 
 </html>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -3,8 +3,15 @@ import { timeHandlers } from './time.js';
 import { elements } from './elements.js';
 import { partners } from './partners.js';
 import { slider } from './slider.js';
+import { parseQueryString } from './util.js';
 
 document.onload = (() => {
+    if (location.search !== null) {
+        const { m, s } = parseQueryString(location.search);
+        elements.time.minutes().textContent = m || '00';
+        elements.time.seconds().textContent = s || '00';
+        buttonHandlers.start();
+    }
 
     elements.time.time().addEventListener('mousemove', buttonHandlers.pause);
     elements.time.time().addEventListener('mouseleave', buttonHandlers.start);

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -1,0 +1,8 @@
+export function parseQueryString(query) {
+    if (query === null) {
+        return null;
+    } else {
+        const tokens = query.split('?')[1].split('&').map(t => t.split('='));
+        return tokens.reduce((p, [k, v]) => Object.assign(p, { [k]: v }), {});
+    }
+}


### PR DESCRIPTION
If the page is opened with a query string in the address bar, the timer will initialize itself with the given values and begin counting down immediately. Regular interactions are still possible (you can adjust the timer while it's running).

Use query token `m` to set starting minutes and token `s` to set starting seconds. They can be used in combination or seperately. Examples:
* `?m=4&s=30` initialize the timer to 4 minutes and 30 seconds
* `?m=10` initialize the timer to 10 minutes