### PR TITLE
Fix preset buttons not working after timer has run to zero

### DIFF
--- a/scripts/animations.js
+++ b/scripts/animations.js
@@ -26,7 +26,7 @@ function startUpdateSeconds(elapsedTime) {
             const changedMinutes = minutes - 1;
             elements.time.minutes().textContent = formatTimeContent(changedMinutes);
             elements.time.seconds().textContent = 59;
-        } else if (parseQueryString(location.search).prep) {
+        } else if (parseQueryString(location.search)?.prep) {
             elements.time.minutes().textContent = formatTimeContent(getMinutesToSet());
         }
     }

--- a/scripts/animations.js
+++ b/scripts/animations.js
@@ -1,4 +1,5 @@
 import { elements } from './elements.js';
+import { setTimerZeroReached } from './controls.js';
 
 import {
     formatTimeContent,
@@ -22,6 +23,11 @@ function startUpdateSeconds(elapsedTime) {
         if (seconds > 0) {
             const changedSeconds = seconds - 1;
             elements.time.seconds().textContent = formatTimeContent(changedSeconds);
+            if(changedSeconds === 0 && minutes == 0) {
+                setTimerZeroReached();
+                cancelAnimationFrame(animationId);
+                return;
+            }
         } else if (minutes > 0) {
             const changedMinutes = minutes - 1;
             elements.time.minutes().textContent = formatTimeContent(changedMinutes);

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -12,10 +12,15 @@ export function controlCenter() {
         animationFrame.stopUpdateSeconds();
     }
 
-    toggleTimerState(timerState(), isStarted);
     isStarted = !isStarted;
+    toggleTimerState(timerState(), isStarted);
 };
 
 export function isStartedYet() {
     return isStarted;
 };
+
+export function setTimerZeroReached() {
+    isStarted = false;
+    toggleTimerState(timerState(), isStarted);
+}


### PR DESCRIPTION
Was listening to the shelly course and it seemed silly, that the lecturer had to restart the timer by refreshing the page, because the modal buttons didn't work after the timer reached zero.